### PR TITLE
Provide an integration case for ShardingSphere JDBC 5.0.0

### DIFF
--- a/third-part-samples/pom.xml
+++ b/third-part-samples/pom.xml
@@ -16,5 +16,6 @@
     <modules>
         <module>quartz-sample</module>
         <module>sharding-jdbc-sample</module>
+        <module>shardingSphere-jdbc-sample</module>
     </modules>
 </project>

--- a/third-part-samples/shardingSphere-jdbc-sample/pom.xml
+++ b/third-part-samples/shardingSphere-jdbc-sample/pom.xml
@@ -21,10 +21,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
         </dependency>

--- a/third-part-samples/shardingSphere-jdbc-sample/pom.xml
+++ b/third-part-samples/shardingSphere-jdbc-sample/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>third-part-samples</artifactId>
+        <groupId>com.baomidou</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>shardingSphere-jdbc-sample</artifactId>
+
+    <properties>
+        <shardingsphere.version>5.0.0</shardingsphere.version>
+        <h2.version>1.4.200</h2.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>dynamic-datasource-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-jdbc-core-spring-boot-starter</artifactId>
+            <version>${shardingsphere.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mybatis.spring.boot</groupId>
+            <artifactId>mybatis-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/ShardingSphereApplication.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/ShardingSphereApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © ${project.inceptionYear} organization baomidou
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.samples.shardingSphere;
+
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+@MapperScan("com.baomidou.samples.shardingSphere.mapper")
+public class ShardingSphereApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ShardingSphereApplication.class, args);
+    }
+}

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/config/MyDataSourceConfiguration.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/config/MyDataSourceConfiguration.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © ${project.inceptionYear} organization baomidou
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.samples.shardingSphere.config;
+
+import com.baomidou.dynamic.datasource.DynamicRoutingDataSource;
+import com.baomidou.dynamic.datasource.provider.AbstractDataSourceProvider;
+import com.baomidou.dynamic.datasource.provider.DynamicDataSourceProvider;
+import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DynamicDataSourceProperties;
+import org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import javax.annotation.Resource;
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class MyDataSourceConfiguration {
+
+    @Resource
+    private DynamicDataSourceProperties properties;
+
+    @Resource
+    private ShardingSphereDataSource shardingSphereDataSource;
+
+    @Bean
+    public DynamicDataSourceProvider dynamicDataSourceProvider() {
+        return new AbstractDataSourceProvider() {
+
+            @Override
+            public Map<String, DataSource> loadDataSources() {
+                Map<String, DataSource> dataSourceMap = new HashMap<>();
+                dataSourceMap.put("shardingSphere", shardingSphereDataSource);
+                return dataSourceMap;
+            }
+        };
+    }
+
+    @Primary
+    @Bean
+    public DataSource dataSource() {
+        DynamicRoutingDataSource dataSource = new DynamicRoutingDataSource();
+        dataSource.setPrimary(properties.getPrimary());
+        dataSource.setStrict(properties.getStrict());
+        dataSource.setStrategy(properties.getStrategy());
+        dataSource.setP6spy(properties.getP6spy());
+        dataSource.setSeata(properties.getSeata());
+        return dataSource;
+    }
+}

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/config/MyDataSourceConfiguration.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/config/MyDataSourceConfiguration.java
@@ -31,7 +31,6 @@ import java.util.Map;
 
 @Configuration
 public class MyDataSourceConfiguration {
-
     @Resource
     private DynamicDataSourceProperties properties;
 

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/controller/UserController.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/controller/UserController.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © ${project.inceptionYear} organization baomidou
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.samples.shardingSphere.controller;
+
+import com.baomidou.samples.shardingSphere.entity.User;
+import com.baomidou.samples.shardingSphere.service.UserService;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Random;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+
+    private static final Random RANDOM = new Random();
+    private final UserService userService;
+
+    @GetMapping("master")
+    public List<User> master() {
+        return userService.selectUsersFromMaster();
+    }
+
+    @GetMapping("sharding_sphere")
+    public List<User> shardingSlave() {
+        return userService.selectUsersFromShardingSlave();
+    }
+
+    @PostMapping("sharding_sphere")
+    public User addUser() {
+        User user = new User();
+        user.setName("测试用户" + RANDOM.nextInt());
+        user.setAge(RANDOM.nextInt(100));
+        userService.addUser(user);
+        return user;
+    }
+
+    @DeleteMapping("sharding_sphere/{id}")
+    public String deleteUser(@PathVariable Long id) {
+        userService.deleteUserById(id);
+        return "成功删除用户" + id;
+    }
+}

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/controller/UserController.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/controller/UserController.java
@@ -27,7 +27,6 @@ import java.util.Random;
 @AllArgsConstructor
 @RequestMapping("/users")
 public class UserController {
-
     private static final Random RANDOM = new Random();
     private final UserService userService;
 

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/dto/UserDto.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/dto/UserDto.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © ${project.inceptionYear} organization baomidou
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.samples.shardingSphere.dto;
+
+import lombok.Data;
+
+@Data
+public class UserDto {
+    private Integer id;
+    private String name;
+    private Integer age;
+}

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/entity/User.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/entity/User.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © ${project.inceptionYear} organization baomidou
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.samples.shardingSphere.entity;
+
+import lombok.Data;
+
+@Data
+public class User {
+    private Integer id;
+    private String name;
+    private Integer age;
+}

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/mapper/UserMapper.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/mapper/UserMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © ${project.inceptionYear} organization baomidou
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.samples.shardingSphere.mapper;
+
+import com.baomidou.samples.shardingSphere.entity.User;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+
+public interface UserMapper {
+
+    @Select("SELECT * FROM user")
+    List<User> selectUsers();
+
+    @Insert("INSERT INTO user (name,age) values (#{name},#{age})")
+    boolean addUser(@Param("name") String name, @Param("age") Integer age);
+
+    @Delete("DELETE from user where id = #{id}")
+    void deleteUserById(Long id);
+}

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/mapper/UserMapper.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/mapper/UserMapper.java
@@ -24,7 +24,6 @@ import org.apache.ibatis.annotations.Select;
 import java.util.List;
 
 public interface UserMapper {
-
     @Select("SELECT * FROM user")
     List<User> selectUsers();
 

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/service/UserService.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/service/UserService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © ${project.inceptionYear} organization baomidou
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.samples.shardingSphere.service;
+
+
+import com.baomidou.samples.shardingSphere.entity.User;
+
+import java.util.List;
+
+public interface UserService {
+
+
+    List<User> selectUsersFromMaster();
+
+    List<User> selectUsersFromShardingSlave();
+
+    void addUser(User user);
+
+    void deleteUserById(Long id);
+}

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/service/UserService.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/service/UserService.java
@@ -15,7 +15,6 @@
  */
 package com.baomidou.samples.shardingSphere.service;
 
-
 import com.baomidou.samples.shardingSphere.entity.User;
 
 import java.util.List;

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/service/UserService.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/service/UserService.java
@@ -21,8 +21,6 @@ import com.baomidou.samples.shardingSphere.entity.User;
 import java.util.List;
 
 public interface UserService {
-
-
     List<User> selectUsersFromMaster();
 
     List<User> selectUsersFromShardingSlave();

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/service/impl/UserServiceImpl.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/service/impl/UserServiceImpl.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 @Service
 public class UserServiceImpl implements UserService {
-
     @Resource
     private UserMapper userMapper;
 

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/service/impl/UserServiceImpl.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/service/impl/UserServiceImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © ${project.inceptionYear} organization baomidou
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.samples.shardingSphere.service.impl;
+
+
+import com.baomidou.dynamic.datasource.annotation.DS;
+import com.baomidou.samples.shardingSphere.entity.User;
+import com.baomidou.samples.shardingSphere.mapper.UserMapper;
+import com.baomidou.samples.shardingSphere.service.UserService;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+import java.util.List;
+
+@Service
+public class UserServiceImpl implements UserService {
+
+    @Resource
+    private UserMapper userMapper;
+
+    @Override
+    public List<User> selectUsersFromMaster() {
+        return userMapper.selectUsers();
+    }
+
+    @Override
+    @DS("shardingSphere")
+    public List<User> selectUsersFromShardingSlave() {
+        return userMapper.selectUsers();
+    }
+
+    @DS("shardingSphere")
+    @Override
+    public void addUser(User user) {
+        userMapper.addUser(user.getName(), user.getAge());
+    }
+
+    @DS("shardingSphere")
+    @Override
+    public void deleteUserById(Long id) {
+        userMapper.deleteUserById(id);
+    }
+}

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/service/impl/UserServiceImpl.java
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/java/com/baomidou/samples/shardingSphere/service/impl/UserServiceImpl.java
@@ -15,7 +15,6 @@
  */
 package com.baomidou.samples.shardingSphere.service.impl;
 
-
 import com.baomidou.dynamic.datasource.annotation.DS;
 import com.baomidou.samples.shardingSphere.entity.User;
 import com.baomidou.samples.shardingSphere.mapper.UserMapper;

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/resources/application.yml
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/resources/application.yml
@@ -5,13 +5,13 @@ spring:
       shardingmaster:
         type: com.zaxxer.hikari.HikariDataSource
         driver-class-name: org.h2.Driver
-        jdbc-url: jdbc:h2:mem:master;MODE=MYSQL;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+        jdbc-url: jdbc:h2:mem:master;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
         username: sa
         password: ""
       shardingslave0:
         type: com.zaxxer.hikari.HikariDataSource
         driver-class-name: org.h2.Driver
-        jdbc-url: jdbc:h2:mem:slave1;MODE=MYSQL;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+        jdbc-url: jdbc:h2:mem:slave1;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
         username: sa
         password: ""
       shardingslave1:
@@ -60,12 +60,12 @@ spring:
         master:
           username: sa
           password: ""
-          url: jdbc:h2:mem:master;MODE=MYSQL;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+          url: jdbc:h2:mem:master;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
           driver-class-name: org.h2.Driver
         test:
           username: sa
           password: ""
-          url: jdbc:h2:mem:test;MODE=MYSQL;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+          url: jdbc:h2:mem:test;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
           driver-class-name: org.h2.Driver
 logging:
   level:

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/resources/application.yml
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/resources/application.yml
@@ -1,0 +1,73 @@
+spring:
+  shardingsphere:
+    datasource:
+      names: shardingmaster,shardingslave0,shardingslave1
+      shardingmaster:
+        type: com.zaxxer.hikari.HikariDataSource
+        driver-class-name: org.h2.Driver
+        jdbc-url: jdbc:h2:mem:master;MODE=MYSQL;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+        username: sa
+        password: ""
+      shardingslave0:
+        type: com.zaxxer.hikari.HikariDataSource
+        driver-class-name: org.h2.Driver
+        jdbc-url: jdbc:h2:mem:slave1;MODE=MYSQL;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+        username: sa
+        password: ""
+      shardingslave1:
+        type: com.zaxxer.hikari.HikariDataSource
+        driver-class-name: org.h2.Driver
+        jdbc-url: jdbc:h2:mem:slave2;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+        username: sa
+        password: ""
+    rules:
+      sharding:
+        tables:
+          t_order:
+            actualDataNodes: shardingmaster.t_order${0..1}
+            tableStrategy:
+              standard:
+                shardingColumn: order_id
+                shardingAlgorithmName: baomidou-inline
+            keyGenerateStrategy:
+              column: order_id
+              keyGeneratorName: baomidou-snowflake
+        sharding-algorithms:
+          baomidou-inline:
+            type: INLINE
+            props:
+              algorithm-expression: t_order$->{order_id % 2}
+              allow-range-query-with-inline-sharding: false
+        key-generators:
+          baomidou-snowflake:
+            type: SNOWFLAKE
+            props:
+              worker-id: 0
+              max-vibration-offset: 1
+              max-tolerate-time-difference-milliseconds: 10
+      readwrite-splitting:
+        data-sources:
+          baomidou-readwrite-data-sources:
+            write-data-source-name: shardingmaster
+            read-data-source-names: shardingslave0,shardingslave1
+            load-balancer-name: baomidou-load-balance-algorithm
+        load-balancers:
+          baomidou-load-balance-algorithm:
+            type: ROUND_ROBIN
+  datasource:
+    dynamic:
+      datasource:
+        master:
+          username: sa
+          password: ""
+          url: jdbc:h2:mem:master;MODE=MYSQL;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+          driver-class-name: org.h2.Driver
+        test:
+          username: sa
+          password: ""
+          url: jdbc:h2:mem:test;MODE=MYSQL;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+          driver-class-name: org.h2.Driver
+logging:
+  level:
+    com.baomidou: debug
+    org.apache.shardingsphere: debug

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/resources/application.yml
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/resources/application.yml
@@ -49,7 +49,9 @@ spring:
         data-sources:
           baomidou-readwrite-data-sources:
             write-data-source-name: shardingmaster
-            read-data-source-names: shardingslave0,shardingslave1
+            read-data-source-names:
+              - shardingslave0
+              - shardingslave1
             load-balancer-name: baomidou-load-balance-algorithm
         load-balancers:
           baomidou-load-balance-algorithm:

--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/resources/db/schema.sql
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/resources/db/schema.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS `USER`
+(
+    `id`   BIGINT(20)  NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(30) NULL DEFAULT NULL,
+    `age`  INT(11)     NULL DEFAULT NULL,
+    PRIMARY KEY (`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `t_order0`
+(
+    `order_id` BIGINT(20)  NOT NULL AUTO_INCREMENT,
+    `name`     VARCHAR(30) NULL DEFAULT NULL,
+    `user_id`  BIGINT(20)  NULL DEFAULT NULL,
+    PRIMARY KEY (`order_id`)
+);
+
+CREATE TABLE IF NOT EXISTS `t_order1`
+(
+    `order_id` BIGINT(20)  NOT NULL AUTO_INCREMENT,
+    `name`     VARCHAR(30) NULL DEFAULT NULL,
+    `user_id`  BIGINT(20)  NULL DEFAULT NULL,
+    PRIMARY KEY (`order_id`)
+);


### PR DESCRIPTION
- Add `shardingSphere-jdbc-sample` to the submodule of `third-part-samples` to provide integration of `org.apache.shardingsphere:shardingsphere-jdbc-core-spring-boot-starter:5.0.0` with multiple data sources Example.
- Affected by https://github.com/apache/shardingsphere/pull/14617, there is an issue between ShardingSphere `5.0.0 `currently and the `2.0.206` version of the H2 database, ShardingSphere retrieves the wrong H2 database metadata, so I limited the version is `1.4.200`. When the problem mentioned in this PR is resolved, the H2 database will continue to use version `2.X`. ( Yes, ShardingSphere has been using H2 `1.X` version for testing before. )
- The case is modified based on `sharding-jdbc-sample`, but I didn't find where to modify the documentation.