### PR TITLE
Update ShardingSphere JDBC to 5.1.0

### DIFF
--- a/third-part-samples/shardingSphere-jdbc-sample/src/main/resources/application.yml
+++ b/third-part-samples/shardingSphere-jdbc-sample/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 spring:
   shardingsphere:
+    mode:
+      type: Memory
     datasource:
       names: shardingmaster,shardingslave0,shardingslave1
       shardingmaster:
@@ -24,7 +26,7 @@ spring:
       sharding:
         tables:
           t_order:
-            actualDataNodes: shardingmaster.t_order${0..1}
+            actualDataNodes: shardingmaster.t_order$->{0..1}
             tableStrategy:
               standard:
                 shardingColumn: order_id
@@ -37,7 +39,7 @@ spring:
             type: INLINE
             props:
               algorithm-expression: t_order$->{order_id % 2}
-              allow-range-query-with-inline-sharding: false
+              allow-range-query-with-inline-sharding: true
         key-generators:
           baomidou-snowflake:
             type: SNOWFLAKE


### PR DESCRIPTION
- Update ShardingSphere JDBC to 5.1.0
- Handle some configuration issues.
- It is still required that the H2database version used is lower than 2.0