### PR TITLE
Update Apache ShardingSphere to 5.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,11 @@ jobs:
           cache: 'maven'
       - name: Build datasource test with Maven
         run: |
-          ./mvnw -am -pl datasource-samples/druid-sample -B clean test
+          ./mvnw -am -pl datasource-samples/druid-sample -T1C -B clean test
       - name: Build orm test with Maven
         run: |
-          ./mvnw -am -pl orm-samples/mybatis-sample -B clean test
+          ./mvnw -am -pl orm-samples/mybatis-sample -T1C -B clean test
       - name: Build third-part test with Maven
         run: |
-          ./mvnw -am -pl third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample -B clean test
-          ./mvnw -am -pl third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample -B clean test
+          ./mvnw -am -pl third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample -T1C -B clean test
+          ./mvnw -am -pl third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample -T1C -B clean test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 所有数据库连接为h2数据库，仅供测试。
 
-所有测试可直接跑，注意观察启动的日志。
+所有测试可在 OpenJDK 17 / OpenJDK 20 及其下游发行版直接跑，注意观察启动的日志。
 
 - add-remove-datasource 动态添加删除数据源的使用示例
 - all-datasource-sample 所有不同连接池使用示例（大乱炖，实际不建议）
@@ -16,7 +16,7 @@
 - nest-sample 嵌套切换数据源使用示例
 - quartz-sample 多数据源集成quartz示例
 - shardingsphere-jdbc-4.x-spring-sample 集成 ShardingSphere JDBC Spring Boot Starter 4.1.1 使用示例, 不再维护, 参考 https://github.com/apache/shardingsphere/releases/tag/5.0.0-alpha
-- shardingsphere-jdbc-5.x-core-sample 集成 ShardingSphere JDBC Driver 5.3.2 使用示例
+- shardingsphere-jdbc-5.x-core-sample 集成 ShardingSphere JDBC Driver 5.4.0 使用示例
 - shardingsphere-jdbc-5.x-spring-sample 集成 ShardingSphere JDBC Spring Boot Starter 5.2.1 使用示例, 不再维护, 参考 https://github.com/apache/shardingsphere/issues/22469
 - spel-sample 动态从外部参数spel来切换数据源的使用示例
 - tx-local-sample 本地事务示例项目★★★★★★必看★★★★★★

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/pom.xml
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>shardingsphere-jdbc-5.x-core-sample</artifactId>
 
     <properties>
-        <shardingsphere.version>5.3.2</shardingsphere.version>
+        <shardingsphere.version>5.4.0</shardingsphere.version>
     </properties>
 
     <dependencies>

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/src/main/java/com/baomidou/samples/shardingsphere/jdbc/v5/core/mapper/TOrderMapper.java
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/src/main/java/com/baomidou/samples/shardingsphere/jdbc/v5/core/mapper/TOrderMapper.java
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
+@SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection", "SqlResolve", "SqlWithoutWhere", "UnusedReturnValue"})
 @Component
 public interface TOrderMapper {
     @Select("select * from t_order")

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/src/main/java/com/baomidou/samples/shardingsphere/jdbc/v5/core/service/impl/TOrderServiceImpl.java
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/src/main/java/com/baomidou/samples/shardingsphere/jdbc/v5/core/service/impl/TOrderServiceImpl.java
@@ -42,7 +42,7 @@ public class TOrderServiceImpl implements TOrderService {
     @DS("shardingSphere")
     public List<TOrder> addAll() {
         IntStream.range(0, 5)
-                .forEach(i -> tOrderMapper.addAll(i + 114514L, "测试" + i, (long) i));
+                .forEach(i -> tOrderMapper.addByNameAndUserId("测试" + i, (long) i));
         return tOrderMapper.findAll();
     }
 }

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/src/main/resources/application.yml
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/src/main/resources/application.yml
@@ -1,6 +1,3 @@
-mybatis:
-  configuration:
-    map-underscore-to-camel-case: true
 spring:
   datasource:
     dynamic:
@@ -8,12 +5,12 @@ spring:
         master:
           username: sa
           password: ""
-          url: jdbc:h2:mem:master;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+          url: jdbc:h2:mem:baomidou_master;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
           driver-class-name: org.h2.Driver
         test:
           username: sa
           password: ""
-          url: jdbc:h2:mem:test;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+          url: jdbc:h2:mem:baomidou_test;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
           driver-class-name: org.h2.Driver
         shardingSphere:
           url: jdbc:shardingsphere:classpath:config.yaml
@@ -21,4 +18,3 @@ spring:
 logging:
   level:
     com.baomidou: debug
-    org.apache.shardingsphere: debug

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/src/main/resources/config.yaml
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/src/main/resources/config.yaml
@@ -2,56 +2,57 @@ dataSources:
   shardingmaster:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.h2.Driver
-    jdbcUrl: jdbc:h2:mem:master;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+    jdbcUrl: jdbc:h2:mem:master;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
     username: sa
-    password: ""
+    password:
   shardingslave0:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.h2.Driver
-    jdbcUrl: jdbc:h2:mem:slave1;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+    jdbcUrl: jdbc:h2:mem:slave1;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
     username: sa
-    password: ""
+    password:
   shardingslave1:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.h2.Driver
-    jdbcUrl: jdbc:h2:mem:slave2;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+    jdbcUrl: jdbc:h2:mem:slave2;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
     username: sa
-    password: ""
+    password:
     
 rules:
-  - !SHARDING
-    tables:
-      t_order:
-        actualDataNodes: shardingmaster.t_order$->{0..1}
-        tableStrategy:
-          standard:
-            shardingColumn: order_id
-            shardingAlgorithmName: baomidou-inline
-        keyGenerateStrategy:
-          column: order_id
-          keyGeneratorName: baomidou-snowflake
-    shardingAlgorithms:
-      baomidou-inline:
-        type: INLINE
-        props:
-          algorithm-expression: t_order$->{order_id % 2}
-          allow-range-query-with-inline-sharding: true
-    keyGenerators:
-      baomidou-snowflake:
-        type: SNOWFLAKE
-        props:
-          max-vibration-offset: 1
-          max-tolerate-time-difference-milliseconds: 10
-          
-  - !READWRITE_SPLITTING
-    dataSources:
-      baomidou-readwrite-data-sources:
-        staticStrategy:
-          writeDataSourceName: shardingmaster
-          readDataSourceNames:
-            - shardingslave0
-            - shardingslave1
-        loadBalancerName: baomidou-load-balance-algorithm
-    loadBalancers:
-      baomidou-load-balance-algorithm:
-        type: ROUND_ROBIN
+- !SHARDING
+  tables:
+    t_order:
+      actualDataNodes: shardingmaster.t_order$->{0..1}
+      tableStrategy:
+        standard:
+          shardingColumn: order_id
+          shardingAlgorithmName: baomidou_inline
+      keyGenerateStrategy:
+        column: order_id
+        keyGeneratorName: baomidou_snowflake
+  shardingAlgorithms:
+    baomidou_inline:
+      type: INLINE
+      props:
+        algorithm-expression: t_order$->{ORDER_ID % 2}
+        allow-range-query-with-inline-sharding: true
+  keyGenerators:
+    baomidou_snowflake:
+      type: SNOWFLAKE
+- !READWRITE_SPLITTING
+  dataSources:
+    baomidou_readwrite_data_sources:
+      writeDataSourceName: shardingmaster
+      readDataSourceNames:
+        - shardingslave0
+        - shardingslave1
+      loadBalancerName: baomidou_load_balance_algorithm
+  loadBalancers:
+    baomidou_load_balance_algorithm:
+      type: ROUND_ROBIN
+- !SINGLE
+  tables:
+    - "*.*"
+
+props:
+  sql-show: true

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/src/main/resources/db/schema.sql
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/src/main/resources/db/schema.sql
@@ -1,23 +1,24 @@
-CREATE TABLE IF NOT EXISTS t_user
+DROP TABLE IF EXISTS `t_user`;
+DROP TABLE IF EXISTS `t_order0`;
+DROP TABLE IF EXISTS `t_order1`;
+
+CREATE TABLE `t_user`
 (
-    `id`   BIGINT(20)  NOT NULL AUTO_INCREMENT,
-    `name` VARCHAR(30) NULL DEFAULT NULL,
-    `age`  INT(11)     NULL DEFAULT NULL,
-    PRIMARY KEY (`id`)
+    `id`   BIGINT PRIMARY KEY,
+    `name` VARCHAR(255),
+    `age`  BIGINT
 );
 
-CREATE TABLE IF NOT EXISTS `t_order0`
+CREATE TABLE `t_order0`
 (
-    `order_id` BIGINT(20)  NOT NULL AUTO_INCREMENT,
-    `name`     VARCHAR(30) NULL DEFAULT NULL,
-    `user_id`  BIGINT(20)  NULL DEFAULT NULL,
-    PRIMARY KEY (`order_id`)
+    `order_id` BIGINT PRIMARY KEY,
+    `name`     VARCHAR(255),
+    `user_id`  BIGINT
 );
 
-CREATE TABLE IF NOT EXISTS `t_order1`
+CREATE TABLE `t_order1`
 (
-    `order_id` BIGINT(20)  NOT NULL AUTO_INCREMENT,
-    `name`     VARCHAR(30) NULL DEFAULT NULL,
-    `user_id`  BIGINT(20)  NULL DEFAULT NULL,
-    PRIMARY KEY (`order_id`)
+    `order_id` BIGINT PRIMARY KEY,
+    `name`     VARCHAR(255),
+    `user_id`  BIGINT
 );

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/src/test/java/com/baomidou/samples/shardingsphere/jdbc/v5/core/MapperLayerTests.java
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/src/test/java/com/baomidou/samples/shardingsphere/jdbc/v5/core/MapperLayerTests.java
@@ -53,30 +53,33 @@ public class MapperLayerTests {
 
     @Test
     void whenRequestToAddByNameAndUserId() {
-        int firstNumberOfAffectedRows = tOrderMapper.addAll(101L, "Bright", 114514L);
-        int secondNumberOfAffectedRows = tOrderMapper.addAll(102L, "Jordan", 114515L);
+        int firstNumberOfAffectedRows = tOrderMapper.addByNameAndUserId("Bright", 114514L);
+        int secondNumberOfAffectedRows = tOrderMapper.addByNameAndUserId("Jordan", 114515L);
         assertEquals(firstNumberOfAffectedRows + secondNumberOfAffectedRows, 2);
         assertEquals(tOrderMapper.findAll().size(), 2);
     }
 
+    /**
+     * TODO Tracked on <a href="https://github.com/apache/shardingsphere/issues/27955">When a logic database uses both `SHARDING` and `READWRITE_SPLITTING` features, CRUD operations on table throw `NoSuchTableException`</a>
+     */
     @Test
-    void whenRequestToAddByNameAndUserIdByMultipleDataNodes() {
+    void whenRequestToAddByNameAndUserIdWithPrimaryKey() {
         List<TOrder> emptyState = tOrderMapper.findAll();
         assertEquals(emptyState.size(), 0);
         assertThrows(DataIntegrityViolationException.class, () -> {
-            tOrderMapper.addByNameAndUserId("Bright", 114514L);
-            tOrderMapper.addByNameAndUserId("Jordan", 114515L);
+            tOrderMapper.addAll(114514L, "Bright", 114514L);
+            tOrderMapper.addAll(114515L, "Jordan", 114515L);
         });
     }
 
     @Test
-    void whenRequestToDeleteByIdTest() {
-        tOrderMapper.addAll(101L, "Bright", 114514L);
-        tOrderMapper.addAll(102L, "Jordan", 114515L);
-        tOrderMapper.addAll(103L, "Lemon", 114516L);
-        tOrderMapper.addAll(104L, "Jack", 114517L);
-        tOrderMapper.addAll(105L, "Michael", 114518L);
-        tOrderMapper.addAll(106L, "Tony", 114519L);
+    void whenRequestToDeleteById() {
+        tOrderMapper.addByNameAndUserId("Bright", 114514L);
+        tOrderMapper.addByNameAndUserId("Jordan", 114515L);
+        tOrderMapper.addByNameAndUserId("Lemon", 114516L);
+        tOrderMapper.addByNameAndUserId("Jack", 114517L);
+        tOrderMapper.addByNameAndUserId("Michael", 114518L);
+        tOrderMapper.addByNameAndUserId("Tony", 114519L);
         int numberOfAffectedRows = tOrderMapper.deleteById(114514L);
         assertEquals(numberOfAffectedRows, 1);
         assertEquals(tOrderMapper.findAll().size(), 5);
@@ -84,12 +87,12 @@ public class MapperLayerTests {
 
     @Test
     void whenRequestToDeleteAll() {
-        tOrderMapper.addAll(101L, "Bright", 114514L);
-        tOrderMapper.addAll(102L, "Jordan", 114515L);
-        tOrderMapper.addAll(103L, "Lemon", 114516L);
-        tOrderMapper.addAll(104L, "Jack", 114517L);
-        tOrderMapper.addAll(105L, "Michael", 114518L);
-        tOrderMapper.addAll(106L, "Tony", 114519L);
+        tOrderMapper.addByNameAndUserId("Bright", 114514L);
+        tOrderMapper.addByNameAndUserId("Jordan", 114515L);
+        tOrderMapper.addByNameAndUserId("Lemon", 114516L);
+        tOrderMapper.addByNameAndUserId("Jack", 114517L);
+        tOrderMapper.addByNameAndUserId("Michael", 114518L);
+        tOrderMapper.addByNameAndUserId("Tony", 114519L);
         int numberOfAffectedRows = tOrderMapper.deleteAll();
         assertEquals(numberOfAffectedRows, 6);
         assertEquals(tOrderMapper.findAll().size(), 0);

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample/src/main/java/com/baomidou/samples/shardingsphere/jdbc/v5/spring/config/MyDataSourceConfiguration.java
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample/src/main/java/com/baomidou/samples/shardingsphere/jdbc/v5/spring/config/MyDataSourceConfiguration.java
@@ -20,6 +20,7 @@ import com.baomidou.dynamic.datasource.creator.DefaultDataSourceCreator;
 import com.baomidou.dynamic.datasource.provider.AbstractDataSourceProvider;
 import com.baomidou.dynamic.datasource.provider.DynamicDataSourceProvider;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DynamicDataSourceProperties;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -32,18 +33,22 @@ import java.util.Map;
 public class MyDataSourceConfiguration {
     private final DynamicDataSourceProperties properties;
     private final DefaultDataSourceCreator dataSourceCreator;
+    private final DataSource shardingSphereDataSource;
 
     /**
-     * 1. 建议 springboot2.5.0 以下版本或者发现不加 @Lazy 值是 null 的情况都打开 @Lazy
+     * 1. 建议 spring-boot 2.5.0 以下版本或者发现不加 `@Lazy` 值是 null 的情况都打开 `@Lazy`
      * 2. Compared with using SpringBoot Starter, if you encounter such problems,
      * you should directly use ShardingSphere's JDBC Driver to configure it as a JDBC data source, that is,
      * use `org.apache.shardingsphere:shardingsphere-jdbc-core:5.2.1` instead of `org.apache.shardingsphere:shardingsphere-jdbc-core-spring-boot-starter:5.2.1`.
      * For more information see <a href="https://shardingsphere.apache.org/document/5.2.1/en/user-manual/shardingsphere-jdbc/yaml-config/jdbc_driver/">JDBC Driver</a>
+     *
+     * @see org.springframework.context.annotation.Lazy
+     * @see org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource
      */
-//    @Lazy
-    private DataSource shardingSphereDataSource;
-
-    public MyDataSourceConfiguration(DynamicDataSourceProperties properties, DefaultDataSourceCreator dataSourceCreator, DataSource shardingSphereDataSource) {
+    public MyDataSourceConfiguration(DynamicDataSourceProperties properties,
+                                     DefaultDataSourceCreator dataSourceCreator,
+//                                     @Lazy
+                                     @Qualifier("shardingSphereDataSource") DataSource shardingSphereDataSource) {
         this.properties = properties;
         this.dataSourceCreator = dataSourceCreator;
         this.shardingSphereDataSource = shardingSphereDataSource;
@@ -55,7 +60,7 @@ public class MyDataSourceConfiguration {
             @Override
             public Map<String, DataSource> loadDataSources() {
                 Map<String, DataSource> dataSourceMap = new HashMap<>();
-                //把shardingSphereDataSource 加入多数据源，到时候使用的时候就可以@DS("shardingSphere")
+                //把 shardingSphereDataSource 加入多数据源，到时候使用的时候就可以 `@DS("shardingSphere")`
                 dataSourceMap.put("shardingSphere", shardingSphereDataSource);
                 return dataSourceMap;
             }

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample/src/main/java/com/baomidou/samples/shardingsphere/jdbc/v5/spring/mapper/TOrderMapper.java
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample/src/main/java/com/baomidou/samples/shardingsphere/jdbc/v5/spring/mapper/TOrderMapper.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-@SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
+@SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection", "SqlResolve", "SqlWithoutWhere", "UnusedReturnValue"})
 public interface TOrderMapper {
     @Select("select * from t_order")
     List<TOrder> findAll();

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample/src/main/java/com/baomidou/samples/shardingsphere/jdbc/v5/spring/service/impl/TOrderServiceImpl.java
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample/src/main/java/com/baomidou/samples/shardingsphere/jdbc/v5/spring/service/impl/TOrderServiceImpl.java
@@ -23,7 +23,9 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.IntStream;
-
+/**
+ * TODO Unit tests for ShardingSphere 5.4.0 need to be synchronized
+ */
 @Service
 public class TOrderServiceImpl implements TOrderService {
     private final TOrderMapper tOrderMapper;

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample/src/main/resources/application.yml
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample/src/main/resources/application.yml
@@ -1,6 +1,3 @@
-mybatis:
-  configuration:
-    map-underscore-to-camel-case: true
 spring:
   shardingsphere:
     datasource:
@@ -8,69 +5,67 @@ spring:
       shardingmaster:
         type: com.zaxxer.hikari.HikariDataSource
         driver-class-name: org.h2.Driver
-        jdbc-url: jdbc:h2:mem:master;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+        jdbc-url: jdbc:h2:mem:master;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
         username: sa
-        password: ""
+        password:
       shardingslave0:
         type: com.zaxxer.hikari.HikariDataSource
         driver-class-name: org.h2.Driver
-        jdbc-url: jdbc:h2:mem:slave1;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+        jdbc-url: jdbc:h2:mem:slave1;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
         username: sa
-        password: ""
+        password:
       shardingslave1:
         type: com.zaxxer.hikari.HikariDataSource
         driver-class-name: org.h2.Driver
-        jdbc-url: jdbc:h2:mem:slave2;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+        jdbc-url: jdbc:h2:mem:slave2;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
         username: sa
-        password: ""
+        password:
     rules:
       sharding:
         tables:
           t_order:
             actualDataNodes: shardingmaster.t_order$->{0..1}
-            tableStrategy:
+            table-strategy:
               standard:
-                shardingColumn: order_id
-                shardingAlgorithmName: baomidou-inline
-            keyGenerateStrategy:
+                sharding-column: order_id
+                sharding-algorithm-name: baomidou_inline
+            key-generate-strategy:
               column: order_id
-              keyGeneratorName: baomidou-snowflake
+              key-generator-name: baomidou_snowflake
         sharding-algorithms:
-          baomidou-inline:
+          baomidou_inline:
             type: INLINE
             props:
               algorithm-expression: t_order$->{order_id % 2}
               allow-range-query-with-inline-sharding: true
         key-generators:
-          baomidou-snowflake:
+          baomidou_snowflake:
             type: SNOWFLAKE
-            props:
-              max-vibration-offset: 1
-              max-tolerate-time-difference-milliseconds: 10
       readwrite-splitting:
         data-sources:
-          baomidou-readwrite-data-sources:
+          baomidou_readwrite_data_sources:
             static-strategy:
               write-data-source-name: shardingmaster
               read-data-source-names: shardingslave0,shardingslave1
-            load-balancer-name: baomidou-load-balance-algorithm
+            load-balancer-name: baomidou_load_balance_algorithm
         load-balancers:
-          baomidou-load-balance-algorithm:
+          baomidou_load_balance_algorithm:
             type: ROUND_ROBIN
+    props:
+      sql-show: true
   datasource:
     dynamic:
       datasource:
         master:
           username: sa
           password: ""
-          url: jdbc:h2:mem:master;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+          url: jdbc:h2:mem:baomidou_master;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
           driver-class-name: org.h2.Driver
         test:
           username: sa
           password: ""
-          url: jdbc:h2:mem:test;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
+          url: jdbc:h2:mem:baomidou_test;INIT=RUNSCRIPT FROM 'classpath:db/schema.sql'
           driver-class-name: org.h2.Driver
 logging:
   level:
     com.baomidou: debug
-    org.apache.shardingsphere: debug

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample/src/main/resources/db/schema.sql
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample/src/main/resources/db/schema.sql
@@ -1,23 +1,24 @@
-CREATE TABLE IF NOT EXISTS t_user
+DROP TABLE IF EXISTS `t_user`;
+DROP TABLE IF EXISTS `t_order0`;
+DROP TABLE IF EXISTS `t_order1`;
+
+CREATE TABLE `t_user`
 (
-    `id`   BIGINT(20)  NOT NULL AUTO_INCREMENT,
-    `name` VARCHAR(30) NULL DEFAULT NULL,
-    `age`  INT(11)     NULL DEFAULT NULL,
-    PRIMARY KEY (`id`)
+    `id`   BIGINT PRIMARY KEY,
+    `name` VARCHAR(255),
+    `age`  BIGINT
 );
 
-CREATE TABLE IF NOT EXISTS `t_order0`
+CREATE TABLE `t_order0`
 (
-    `order_id` BIGINT(20)  NOT NULL AUTO_INCREMENT,
-    `name`     VARCHAR(30) NULL DEFAULT NULL,
-    `user_id`  BIGINT(20)  NULL DEFAULT NULL,
-    PRIMARY KEY (`order_id`)
+    `order_id` BIGINT PRIMARY KEY,
+    `name`     VARCHAR(255),
+    `user_id`  BIGINT
 );
 
-CREATE TABLE IF NOT EXISTS `t_order1`
+CREATE TABLE `t_order1`
 (
-    `order_id` BIGINT(20)  NOT NULL AUTO_INCREMENT,
-    `name`     VARCHAR(30) NULL DEFAULT NULL,
-    `user_id`  BIGINT(20)  NULL DEFAULT NULL,
-    PRIMARY KEY (`order_id`)
+    `order_id` BIGINT PRIMARY KEY,
+    `name`     VARCHAR(255),
+    `user_id`  BIGINT
 );

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample/src/test/java/com/baomidou/samples/shardingsphere/jdbc/v5/spring/MapperLayerTests.java
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample/src/test/java/com/baomidou/samples/shardingsphere/jdbc/v5/spring/MapperLayerTests.java
@@ -30,6 +30,10 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+/**
+ * TODO Unit tests for ShardingSphere 5.4.0 need to be synchronized.
+ *  Tracked on <a href="https://github.com/apache/shardingsphere/issues/27955">When a logic database uses both `SHARDING` and `READWRITE_SPLITTING` features, CRUD operations on table throw `NoSuchTableException`</a>
+ */
 @SpringBootTest
 public class MapperLayerTests {
     @Autowired
@@ -60,7 +64,7 @@ public class MapperLayerTests {
     }
 
     @Test
-    void whenRequestToAddByNameAndUserIdByMultipleDataNodes() {
+    void whenRequestToAddByNameAndUserIdWithPrimaryKey() {
         List<TOrder> emptyState = tOrderMapper.findAll();
         assertEquals(emptyState.size(), 0);
         assertThrows(UncategorizedSQLException.class, () -> {


### PR DESCRIPTION
Changes proposed in this pull request:
  - Update Apache ShardingSphere to 5.4.0
  - Fix the inappropriate configuration of `shardingsphere-jdbc-5.x-spring-sample`.
  - Warning: Now, ShardingSphere is only support algorithm name with `_` separated in `5.4.1-SNAPSHOT`. Refer to https://github.com/apache/shardingsphere/issues/27329 .