### PR TITLE
Use OpenJDK 20 instead of OpenJDK 19 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        java-version: [ 17, 19 ]
+        java-version: [ '17', '20' ]
     steps:
       - uses: actions/checkout@v3
       - name: Setup java


### PR DESCRIPTION
Changes proposed in this pull request:
  - Use OpenJDK 20 instead of OpenJDK 19 in CI.