### PR TITLE
Use OpenJDK 21 instead of OpenJDK 20 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        java-version: [ '8', '17', '20' ]
+        java-version: [ '8', '17', '21-ea' ]
     steps:
       - uses: actions/checkout@v3
       - name: Setup java
@@ -42,11 +42,11 @@ jobs:
           cache: 'maven'
       - name: Build datasource test with Maven
         run: |
-          ./mvnw -am -pl datasource-samples/druid-sample -T1C -B clean test
+          ./mvnw -am -pl datasource-samples/druid-sample -T1C -B -e clean test
       - name: Build orm test with Maven
         run: |
-          ./mvnw -am -pl orm-samples/mybatis-sample -T1C -B clean test
+          ./mvnw -am -pl orm-samples/mybatis-sample -T1C -B -e clean test
       - name: Build third-part test with Maven
         run: |
-          ./mvnw -am -pl third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample -T1C -B clean test
-          ./mvnw -am -pl third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample -T1C -B clean test
+          ./mvnw -am -pl third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample -T1C -B -e clean test
+          ./mvnw -am -pl third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-spring-sample -T1C -B -e clean test

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 所有数据库连接为h2数据库，仅供测试。
 
-所有测试可在 OpenJDK 17 / OpenJDK 20 及其下游发行版直接跑，注意观察启动的日志。 除开 `com.baomidou:springboot3-sample`， 
-其他子模块均可在 OpenJDK 8 下执行单元测试。你可能希望参考 [位于 Github Actions 的 CI 文件](./.github/workflows/ci.yml)。
+所有测试可在 OpenJDK 17 / OpenJDK 21 及其下游发行版直接跑，注意观察启动的日志。 
+除开 `com.baomidou:springboot3-sample`， 其他子模块均可在 OpenJDK 8 下执行单元测试。
+你可能希望参考 [位于 Github Actions 的 CI 文件](./.github/workflows/ci.yml)。
 
 - add-remove-datasource 动态添加删除数据源的使用示例
 - all-datasource-sample 所有不同连接池使用示例（大乱炖，实际不建议）

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <p6spy.version>3.9.1</p6spy.version>
         <h2.version>2.2.220</h2.version>
         <spring-boot-dependencies.version>2.7.13</spring-boot-dependencies.version>
+        <lombok.version>1.18.30</lombok.version>
     </properties>
 
     <modules>
@@ -106,6 +107,13 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Changes proposed in this pull request:

  - Use OpenJDK 21 instead of OpenJDK 20 in CI. Refer to https://adoptium.net/zh-CN/blog/2023/08/early-access-builds/ .