### PR TITLE
Fix the incorrect version number of `mybatis-spring-boot-starter`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <java.version>1.8</java.version>
 
         <ds.version>4.1.3</ds.version>
-        <mybatis-spring-boot-starter.version>3.0.0</mybatis-spring-boot-starter.version>
+        <mybatis-spring-boot-starter.version>2.3.1</mybatis-spring-boot-starter.version>
         <druid.version>1.2.18</druid.version>
         <p6spy.version>3.9.1</p6spy.version>
         <h2.version>2.2.220</h2.version>


### PR DESCRIPTION
- Fix the incorrect version number of `mybatis-spring-boot-starter`, refer to https://github.com/mybatis/spring-boot-starter#readme .