### PR TITLE
Add CI testing for Windows 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ 'ubuntu-latest', 'windows-latest' ]
         java-version: [ '8', '17', '21-ea' ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- For Windows Native Dev.
- Add CI testing for Windows 11.