### PR TITLE
Bump ShardingSphere JDBC in Example to 5.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - quartz-sample 多数据源集成quartz示例
 - shardingsphere-jdbc-4.x-spring-sample 集成 ShardingSphere JDBC Spring Boot Starter 4.1.1 使用示例, 不再维护,
   参考 https://github.com/apache/shardingsphere/releases/tag/5.0.0-alpha
-- shardingsphere-jdbc-5.x-core-sample 集成 ShardingSphere JDBC Driver 5.5.1 使用示例
+- shardingsphere-jdbc-5.x-core-sample 集成 ShardingSphere JDBC Driver 5.5.2 使用示例
 - shardingsphere-jdbc-5.x-spring-sample 集成 ShardingSphere JDBC Spring Boot Starter 5.2.1 使用示例, 不再维护,
   参考 https://github.com/apache/shardingsphere/issues/22469
 - spel-sample 动态从外部参数spel来切换数据源的使用示例

--- a/pom.xml
+++ b/pom.xml
@@ -91,13 +91,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <repositories>
-        <repository>
-            <id>aliyunmaven</id>
-            <url>https://maven.aliyun.com/repository/public</url>
-        </repository>
-    </repositories>
-
     <build>
         <plugins>
             <plugin>

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/pom.xml
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>shardingsphere-jdbc-5.x-core-sample</artifactId>
 
     <properties>
-        <shardingsphere.version>5.5.1</shardingsphere.version>
+        <shardingsphere.version>5.5.2</shardingsphere.version>
     </properties>
 
     <dependencies>
@@ -58,5 +58,4 @@
             <version>2.2</version>
         </dependency>
     </dependencies>
-
 </project>

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/src/main/resources/config.yaml
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/src/main/resources/config.yaml
@@ -34,6 +34,7 @@ rules:
     baomidou_inline:
       type: INLINE
       props:
+        # TODO Affected by https://github.com/apache/shardingsphere/issues/27955 .
         algorithm-expression: t_order$->{ORDER_ID % 2}
         allow-range-query-with-inline-sharding: true
   keyGenerators:


### PR DESCRIPTION
- Bump ShardingSphere JDBC in Example to 5.5.2 .
- https://maven.aliyun.com/repository/public seems to block the IP address of Github Actions Runner, and CI often cannot pull dependent JARs.
- We are still affected by https://github.com/apache/shardingsphere/issues/27955 .