### PR TITLE
Bump testcontainers-java to 2.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ target
 /nbdist/
 /.nb-gradle/
 
-### We don't want to check in any binaries in Git ###
+# We don't want to check in any binaries in Git
 **/.mvn/wrapper/maven-wrapper.jar
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,9 @@
         <h2.version>2.2.224</h2.version>
         <spring-boot-dependencies.version>2.7.18</spring-boot-dependencies.version>
         <lombok.version>1.18.30</lombok.version>
-        <!--TODO We need to change the project's `spring-boot-dependencies.version` to 4.0.0, see https://github.com/testcontainers/testcontainers-java/issues/11236 -->
-        <testcontainers-bom.version>1.21.3</testcontainers-bom.version>
+        <testcontainers-bom.version>2.0.3</testcontainers-bom.version>
+        <!-- TODO See https://github.com/testcontainers/testcontainers-java/issues/11236 -->
+        <jackson-bom.version>2.18.4</jackson-bom.version>
     </properties>
 
     <modules>
@@ -47,6 +48,13 @@
                 <groupId>com.baomidou</groupId>
                 <artifactId>dynamic-datasource-spring-boot3-starter</artifactId>
                 <version>${ds.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>

--- a/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/pom.xml
+++ b/third-part-samples/shardingsphere-sample/shardingsphere-jdbc-5.x-core-sample/pom.xml
@@ -65,7 +65,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -80,7 +80,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mysql</artifactId>
+            <artifactId>testcontainers-mysql</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>


### PR DESCRIPTION
- Bump testcontainers-java to 2.0.3.
- Also see https://github.com/testcontainers/testcontainers-java/issues/11236 .